### PR TITLE
Add 2D_6h_native to IFS-AMIP OSTIA amip-hist runs

### DIFF
--- a/dkrz/disk/model-output/ifs-amip/amip-hist-obs-c-lr30-a-0/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/amip-hist-obs-c-lr30-a-0/atmos/gr025/main.yaml
@@ -1,3 +1,7 @@
+plugins:
+   source:
+   - module: intake_xarray
+   
 sources:
   2D_24h_0.25deg:
     args:
@@ -77,6 +81,12 @@ sources:
         default: 10u
         description: All available variables in the dataset
         type: str
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_c_LR30_a_0/gribscan/2D_6h_native/json.dir/atm2d.json
   2D_monthly_0.25deg:
     args:
       consolidated: false

--- a/dkrz/disk/model-output/ifs-amip/amip-hist-obs-c-lr30-a-lr30/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/amip-hist-obs-c-lr30-a-lr30/atmos/gr025/main.yaml
@@ -1,3 +1,7 @@
+plugins:
+   source:
+   - module: intake_xarray
+   
 sources:
   2D_24h_0.25deg:
     args:
@@ -137,6 +141,12 @@ sources:
         default: 10u
         description: All available variables in the dataset
         type: str
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_c_LR30_a_LR30/gribscan/2D_6h_native/json.dir/atm2d.json
   2D_monthly_0.25deg:
     args:
       consolidated: false

--- a/dkrz/disk/model-output/ifs-amip/amip-hist-obs-lr30/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/amip-hist-obs-lr30/atmos/gr025/main.yaml
@@ -1,3 +1,7 @@
+plugins:
+   source:
+   - module: intake_xarray
+   
 sources:
   2D_24h_0.25deg:
     args:
@@ -94,6 +98,12 @@ sources:
         default: 10u
         description: All available variables in the dataset
         type: str
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_LR30/gribscan/2D_6h_native/json.dir/atm2d.json
   2D_const_0.25deg:
     args:
       path_as_pattern: false

--- a/dkrz/disk/model-output/ifs-amip/amip-hist-obs/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/amip-hist-obs/atmos/gr025/main.yaml
@@ -1,3 +1,7 @@
+plugins:
+   source:
+   - module: intake_xarray
+   
 sources:
   2D_24h_0.25deg:
     args:
@@ -94,6 +98,12 @@ sources:
         default: 10u
         description: All available variables in the dataset
         type: str
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA/gribscan/2D_6h_native/json.dir/atm2d.json
   2D_const_0.25deg:
     args:
       path_as_pattern: false


### PR DESCRIPTION
PR to include 2D_6h_native streams in "gribscan-only" mode, without kerchunk. Delete if superseded by kerchunk-ed variant.

Loading in notebooks works for new and previous streams.

Caveat: requires that environment has "intake-array" installed, which is not the case for "hamburg-hackathon-eddyenv" (but is the case for "python-HH-hackathon").