### PR TITLE
IFS-AMIP: add short tco1279 runs with ESA-CCI-SST v3

### DIFF
--- a/dkrz/disk/model-output/ifs-amip/amip-hist-esav3-c-0-a-lr30/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/amip-hist-esav3-c-0-a-lr30/atmos/gr025/main.yaml
@@ -1,0 +1,49 @@
+sources:
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_24h_0.25deg/json.dir/atm2d.json
+  2D_6h_0.25deg:
+    description: 2D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_6h_0.25deg/json.dir/atm2d.json
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_6h_native/json.dir/atm2d.json
+  2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_const_0.25deg/json.dir/atm2d.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_monthly_0.25deg/json.dir/atm2d.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/3D_24h_0.25deg/json.dir/atm3d.json
+  3D_6h_0.25deg:
+    description: 3D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/3D_6h_0.25deg/json.dir/atm3d.json
+  3D_monthly_0.25deg:
+    description: 3D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/3D_monthly_0.25deg/json.dir/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip/amip-hist-esav3/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/amip-hist-esav3/atmos/gr025/main.yaml
@@ -1,0 +1,49 @@
+sources:
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_24h_0.25deg/json.dir/atm2d.json
+  2D_6h_0.25deg:
+    description: 2D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_6h_0.25deg/json.dir/atm2d.json
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_6h_native/json.dir/atm2d.json
+  2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_const_0.25deg/json.dir/atm2d.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_monthly_0.25deg/json.dir/atm2d.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_24h_0.25deg/json.dir/atm3d.json
+  3D_6h_0.25deg:
+    description: 3D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_6h_0.25deg/json.dir/atm3d.json
+  3D_monthly_0.25deg:
+    description: 3D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_monthly_0.25deg/json.dir/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/main.yaml
@@ -34,3 +34,8 @@ sources:
       path: "{{CATALOG_DIR}}/amip-hist-esav3/atmos/gr025/main.yaml"
     description: This catalog contains EERIE IFS-AMIP amip-hist-esav3 output available at DKRZ disk - ESA-CCI v3 SST and new EERIE configuration 
     driver: yaml_file_cat
+  amip-hist-esav3-c-0-a-lr30.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/amip-hist-esav3-c-0-a-lr30/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-esav3-c-0-a-lr30 output available at DKRZ disk - ESA-CCI v3 SST (LR30 smoothed anomalies) and new EERIE configuration 
+    driver: yaml_file_cat

--- a/dkrz/disk/model-output/ifs-amip/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/main.yaml
@@ -29,3 +29,8 @@ sources:
       path: "{{CATALOG_DIR}}/amip-ng-obs-lr30/atmos/gr025/main.yaml"
     description: This catalog contains EERIE IFS-AMIP amip-hist-obs-lr30 output available at DKRZ disk - smoothed OSTIA SST and NextGEMS cycle3 configuration 
     driver: yaml_file_cat
+  amip-hist-esav3.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/amip-hist-esav3/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-esav3 output available at DKRZ disk - ESA-CCI v3 SST and new EERIE configuration 
+    driver: yaml_file_cat


### PR DESCRIPTION
Short test runs with the same model configuration as the 4 tco399 test runs, except:

- ESA-CCI SST, version 3, instead of OSTIA (ESA-CCI will be used for the production run)
- runs start in 2020-01-01, rather than 2010-01-01
- runs cover 1-2 years, will run until the end of 2021