### PR TITLE
Create IFS-AMIP paths matching the <model>-<resolution> framework, including version numbers

### DIFF
--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -96,39 +96,39 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_min.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_max.json
@@ -234,37 +234,37 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
@@ -416,17 +416,17 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
@@ -466,17 +466,17 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -129,21 +129,21 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_min.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
   2D_24h_0.25deg:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -267,19 +267,19 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
   # 2D_6h_0.25deg:
@@ -427,11 +427,11 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
   3D_24h_0.25deg:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -477,11 +477,11 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
   # 3D_6h_0.25deg:
   #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/main.yaml
@@ -1,0 +1,11 @@
+sources:
+  hist.v20240901.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20240901/atmos/gr025/main.yaml"
+    description: This catalog contains the high-resolution (tco1279, ~ 9km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. 
+    driver: yaml_file_cat
+  hist-c-0-a-lr20.v20240901.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml"
+    description: This catalog contains the high-resolution (tco1279, ~ 9km) EERIE IFS-AMIP *filtered anomalies* historical production run, forced with ESA-CCI v3 SST & sea ice. SST anomalies are filtered with LR20.
+    driver: yaml_file_cat

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231006/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231006/atmos/gr025/main.yaml
@@ -1,0 +1,136 @@
+sources:
+  2D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/dcda/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 100u
+        - 100v
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - ewss
+        - fdir
+        - hcc
+        - i10fg
+        - lcc
+        - lgws
+        - lsm
+        - mcc
+        - mgws
+        - msl
+        - nsss
+        - rsn
+        - sd
+        - sf
+        - skt
+        - slhf
+        - sp
+        - sro
+        - sshf
+        - ssr
+        - ssrd
+        - ssrdc
+        - ssro
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - str
+        - strd
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcrw
+        - tcsw
+        - tcwv
+        - tisr
+        - tp
+        - tsr
+        - ttr
+        - z
+        default: 100u
+        description: All available variables in the dataset
+        type: str
+  2D_6h_0.25deg_lightning:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/lightning/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP - only lightning density
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 2
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - litota6
+        default: litota6
+        description: All available variables in the dataset
+        type: str
+  3D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/dcda/atm3d.parq
+    description: 3D daily variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - cc
+        - ciwc
+        - clwc
+        - crwc
+        - cswc
+        - q
+        - t
+        - u
+        - v
+        - w
+        - z
+        - '~'
+        default: cc
+        description: All available variables in the dataset
+        type: str

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/gr025/main.yaml
@@ -1,0 +1,324 @@
+plugins:
+  source:
+  - module: intake_xarray
+sources:
+  2D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/2D_24h_0.25deg/atm2d.parq
+    description: 2D daily variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - lmlt
+        - mn2t24
+        - mx2t24
+        default: lmlt
+        description: All available variables in the dataset
+        type: str
+  2D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/2D_6h_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cp
+        - e
+        - ewss
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lsp
+        - msl
+        - nsss
+        - ro
+        - sd
+        - sf
+        - skt
+        - slhf
+        - sro
+        - sshf
+        - ssr
+        - ssrd
+        - ssro
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - str
+        - strd
+        - sund
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tisr
+        - tp
+        - tsr
+        - ttr
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_6h_native:
+    args:
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_LR30/gribscan/2D_6h_native/json.dir/atm2d.json
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - ewss
+        - nsss
+        - slhf
+        - sshf
+        - ssr
+        - sst
+        - str
+        - tcc
+        - tp
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_const_0.25deg:
+    args:
+      path_as_pattern: false
+      urlpath: /work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_LR30/gribscan/2D_const_0.25deg/*.grib
+      xarray_kwargs:
+        engine: cfgrib
+    description: 2D constant variables from IFS-AMIP
+    driver: netcdf
+    metadata:
+      Conventions: CF-1.7
+      GRIB_centre: ecmf
+      GRIB_centreDescription: European Centre for Medium-Range Weather Forecasts
+      GRIB_edition: 1
+      GRIB_subCentre: 0
+      history: '2024-03-05T12:10 GRIB to CDM+CF via cfgrib-0.9.10.3/ecCodes-2.29.0
+        with {"source": "../../../../../../../work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_LR30/gribscan/2D_const_0.25deg/mmsf_fc_sfc_26.128_0_7200_0.25.grib",
+        "filter_by_keys": {}, "encode_cf": ["parameter", "time", "geography", "vertical"]}'
+      institution: European Centre for Medium-Range Weather Forecasts
+      variable-long_names:
+      - Lake cover
+      - Lake total depth
+      - Land-sea mask
+      - Geopotential
+    parameters:
+      variables:
+        allowed:
+        - cl
+        - dl
+        - lsm
+        - z
+        default: cl
+        description: All available variables in the dataset
+        type: str
+  2D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/2D_monthly_0.25deg/atm2d.parq
+    description: 2D monthly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10si
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cprate
+        - erate
+        - ewssra
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lmlt
+        - mlsprt
+        - mn2t24
+        - mrort
+        - msdr
+        - msdsrf
+        - msdtrf
+        - msl
+        - mslhfl
+        - msnsrf
+        - msntrf
+        - msror
+        - msshfl
+        - mssror
+        - mtnsrf
+        - mtntrf
+        - mtsfr
+        - mx2t24
+        - nsssra
+        - sd
+        - skt
+        - soira
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tprate
+        default: 10si
+        description: All available variables in the dataset
+        type: str
+  3D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/3D_24h_0.25deg/atm3d.parq
+    description: 3D daily variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - q
+        - t
+        - u
+        - v
+        - z
+        default: q
+        description: All available variables in the dataset
+        type: str
+  3D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/3D_6h_0.25deg/atm3d.parq
+    description: 3D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str
+  3D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: file
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_LR30/3D_monthly_0.25deg/atm3d.parq
+    description: 3D monthly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/main.yaml
@@ -1,0 +1,49 @@
+sources:
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_24h_0.25deg/json.dir/atm2d.json
+  2D_6h_0.25deg:
+    description: 2D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_6h_0.25deg/json.dir/atm2d.json
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_6h_native/json.dir/atm2d.json
+  2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_const_0.25deg/json.dir/atm2d.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_monthly_0.25deg/json.dir/atm2d.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/3D_24h_0.25deg/json.dir/atm3d.json
+  3D_6h_0.25deg:
+    description: 3D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/3D_6h_0.25deg/json.dir/atm3d.json
+  3D_monthly_0.25deg:
+    description: 3D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/3D_monthly_0.25deg/json.dir/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr30-a-0/v20231106/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr30-a-0/v20231106/atmos/gr025/main.yaml
@@ -1,0 +1,288 @@
+sources:
+  2D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        lazy: true
+        remote_protocol: https
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_0_cloud/2D_24h_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - lmlt
+        - mn2t24
+        - mx2t24
+        default: lmlt
+        description: All available variables in the dataset
+        type: str
+  2D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_0_cloud/2D_6h_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cp
+        - e
+        - ewss
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lsp
+        - msl
+        - nsss
+        - ro
+        - sd
+        - sf
+        - skt
+        - slhf
+        - sro
+        - sshf
+        - ssr
+        - ssrd
+        - ssro
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - str
+        - strd
+        - sund
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tisr
+        - tp
+        - tsr
+        - ttr
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_6h_native:
+    args:
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_c_LR30_a_0/gribscan/2D_6h_native/json.dir/atm2d.json
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - ewss
+        - nsss
+        - slhf
+        - sshf
+        - ssr
+        - sst
+        - str
+        - tcc
+        - tp
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_0_cloud/2D_monthly_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10si
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cprate
+        - erate
+        - ewssra
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lmlt
+        - mlsprt
+        - mn2t24
+        - mrort
+        - msdr
+        - msdsrf
+        - msdtrf
+        - msl
+        - mslhfl
+        - msnsrf
+        - msntrf
+        - msror
+        - msshfl
+        - mssror
+        - mtnsrf
+        - mtntrf
+        - mtsfr
+        - mx2t24
+        - nsssra
+        - sd
+        - skt
+        - soira
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tprate
+        default: 10si
+        description: All available variables in the dataset
+        type: str
+  3D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_0_cloud/3D_24h_0.25deg/atm3d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - q
+        - t
+        - u
+        - v
+        - z
+        default: q
+        description: All available variables in the dataset
+        type: str
+  3D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_0_cloud/3D_6h_0.25deg/atm3d.parq
+    description: 3D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str
+  3D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_0_cloud/3D_monthly_0.25deg/atm3d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr30-a-lr30/v20231106/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr30-a-lr30/v20231106/atmos/gr025/main.yaml
@@ -1,0 +1,288 @@
+sources:
+  2D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_LR30_cloud/2D_24h_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - lmlt
+        - mn2t24
+        - mx2t24
+        default: lmlt
+        description: All available variables in the dataset
+        type: str
+  2D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_LR30_cloud/2D_6h_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cp
+        - e
+        - ewss
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lsp
+        - msl
+        - nsss
+        - ro
+        - sd
+        - sf
+        - skt
+        - slhf
+        - sro
+        - sshf
+        - ssr
+        - ssrd
+        - ssro
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - str
+        - strd
+        - sund
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tisr
+        - tp
+        - tsr
+        - ttr
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_6h_native:
+    args:
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA_c_LR30_a_LR30/gribscan/2D_6h_native/json.dir/atm2d.json
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - ewss
+        - nsss
+        - slhf
+        - sshf
+        - ssr
+        - sst
+        - str
+        - tcc
+        - tp
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_LR30_cloud/2D_monthly_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10si
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cprate
+        - erate
+        - ewssra
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lmlt
+        - mlsprt
+        - mn2t24
+        - mrort
+        - msdr
+        - msdsrf
+        - msdtrf
+        - msl
+        - mslhfl
+        - msnsrf
+        - msntrf
+        - msror
+        - msshfl
+        - mssror
+        - mtnsrf
+        - mtntrf
+        - mtsfr
+        - mx2t24
+        - nsssra
+        - sd
+        - skt
+        - soira
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tprate
+        default: 10si
+        description: All available variables in the dataset
+        type: str
+  3D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_LR30_cloud/3D_24h_0.25deg/atm3d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - q
+        - t
+        - u
+        - v
+        - z
+        default: q
+        description: All available variables in the dataset
+        type: str
+  3D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_LR30_cloud/3D_6h_0.25deg/atm3d.parq
+    description: 3D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str
+  3D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_c_LR30_a_LR30_cloud/3D_monthly_0.25deg/atm3d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20231006/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20231006/atmos/gr025/main.yaml
@@ -1,0 +1,136 @@
+sources:
+  2D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/dcda/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 100u
+        - 100v
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - ewss
+        - fdir
+        - hcc
+        - i10fg
+        - lcc
+        - lgws
+        - lsm
+        - mcc
+        - mgws
+        - msl
+        - nsss
+        - rsn
+        - sd
+        - sf
+        - skt
+        - slhf
+        - sp
+        - sro
+        - sshf
+        - ssr
+        - ssrd
+        - ssrdc
+        - ssro
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - str
+        - strd
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcrw
+        - tcsw
+        - tcwv
+        - tisr
+        - tp
+        - tsr
+        - ttr
+        - z
+        default: 100u
+        description: All available variables in the dataset
+        type: str
+  2D_6h_0.25deg_lightning:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/lightning/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP - only lightning density
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 2
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - litota6
+        default: litota6
+        description: All available variables in the dataset
+        type: str
+  3D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/dcda/atm3d.parq
+    description: 3D daily variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - cc
+        - ciwc
+        - clwc
+        - crwc
+        - cswc
+        - q
+        - t
+        - u
+        - v
+        - w
+        - z
+        - '~'
+        default: cc
+        description: All available variables in the dataset
+        type: str

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20231106/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20231106/atmos/gr025/main.yaml
@@ -1,0 +1,324 @@
+plugins:
+  source:
+  - module: intake_xarray
+sources:
+  2D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/2D_24h_0.25deg/atm2d.parq
+    description: 2D daily variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - lmlt
+        - mn2t24
+        - mx2t24
+        default: lmlt
+        description: All available variables in the dataset
+        type: str
+  2D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/2D_6h_0.25deg/atm2d.parq
+    description: 2D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cp
+        - e
+        - ewss
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lsp
+        - msl
+        - nsss
+        - ro
+        - sd
+        - sf
+        - skt
+        - slhf
+        - sro
+        - sshf
+        - ssr
+        - ssrd
+        - ssro
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - str
+        - strd
+        - sund
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tisr
+        - tp
+        - tsr
+        - ttr
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_6h_native:
+    args:
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA/gribscan/2D_6h_native/json.dir/atm2d.json
+    description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10u
+        - 10v
+        - ewss
+        - nsss
+        - slhf
+        - sshf
+        - ssr
+        - sst
+        - str
+        - tcc
+        - tp
+        default: 10u
+        description: All available variables in the dataset
+        type: str
+  2D_const_0.25deg:
+    args:
+      path_as_pattern: false
+      urlpath: /work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA/gribscan/2D_const_0.25deg/*.grib
+      xarray_kwargs:
+        engine: cfgrib
+    description: 2D constant variables from IFS-AMIP
+    driver: netcdf
+    metadata:
+      Conventions: CF-1.7
+      GRIB_centre: ecmf
+      GRIB_centreDescription: European Centre for Medium-Range Weather Forecasts
+      GRIB_edition: 1
+      GRIB_subCentre: 0
+      history: '2024-03-05T12:10 GRIB to CDM+CF via cfgrib-0.9.10.3/ecCodes-2.29.0
+        with {"source": "../../../../../../../work/bk1377/b382473/IFS_AMIP/prepIFS/OSTIA/gribscan/2D_const_0.25deg/mmsf_fc_sfc_26.128_0_7200_0.25.grib",
+        "filter_by_keys": {}, "encode_cf": ["parameter", "time", "geography", "vertical"]}'
+      institution: European Centre for Medium-Range Weather Forecasts
+      variable-long_names:
+      - Lake cover
+      - Lake total depth
+      - Land-sea mask
+      - Geopotential
+    parameters:
+      variables:
+        allowed:
+        - cl
+        - dl
+        - lsm
+        - z
+        default: cl
+        description: All available variables in the dataset
+        type: str
+  2D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/2D_monthly_0.25deg/atm2d.parq
+    description: 2D monthly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - 10si
+        - 10u
+        - 10v
+        - 2d
+        - 2t
+        - cape
+        - ci
+        - cprate
+        - erate
+        - ewssra
+        - fal
+        - iews
+        - inss
+        - lcc
+        - lmlt
+        - mlsprt
+        - mn2t24
+        - mrort
+        - msdr
+        - msdsrf
+        - msdtrf
+        - msl
+        - mslhfl
+        - msnsrf
+        - msntrf
+        - msror
+        - msshfl
+        - mssror
+        - mtnsrf
+        - mtntrf
+        - mtsfr
+        - mx2t24
+        - nsssra
+        - sd
+        - skt
+        - soira
+        - sst
+        - stl1
+        - stl2
+        - stl3
+        - stl4
+        - swvl1
+        - swvl2
+        - swvl3
+        - swvl4
+        - tcc
+        - tciw
+        - tclw
+        - tcwv
+        - tprate
+        default: 10si
+        description: All available variables in the dataset
+        type: str
+  3D_24h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/3D_24h_0.25deg/atm3d.parq
+    description: 3D daily variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - q
+        - t
+        - u
+        - v
+        - z
+        default: q
+        description: All available variables in the dataset
+        type: str
+  3D_6h_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/3D_6h_0.25deg/atm3d.parq
+    description: 3D 6-hourly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str
+  3D_monthly_0.25deg:
+    args:
+      consolidated: false
+      storage_options:
+        remote_protocol: https
+        lazy: true
+      urlpath: reference::/work/bm1344/DKRZ/kerchunks_batched/ifs-amip_OSTIA_cloud/3D_monthly_0.25deg/atm3d.parq
+    description: 3D monthly variables from IFS-AMIP
+    driver: zarr
+    metadata:
+      centre: ecmf
+      centreDescription: European Centre for Medium-Range Weather Forecasts
+      edition: 1
+      history: "\U0001FA84\U0001F9D9\u200D\u2642\uFE0F\U0001F52E magic dataset assembly\
+        \ provided by gribscan.IFSMagician\r\n"
+      subCentre: 0
+      variable-long_names: []
+    parameters:
+      variables:
+        allowed:
+        - d
+        - q
+        - t
+        - u
+        - v
+        - vo
+        - z
+        default: d
+        description: All available variables in the dataset
+        type: str

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240304/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240304/atmos/gr025/main.yaml
@@ -1,0 +1,49 @@
+sources:
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_24h_0.25deg/json.dir/atm2d.json
+  2D_6h_0.25deg:
+    description: 2D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_6h_0.25deg/json.dir/atm2d.json
+  2D_6h_native:
+    description: 2D 6-hourly variables from IFS-AMIP on native grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_6h_native/json.dir/atm2d.json
+  2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_const_0.25deg/json.dir/atm2d.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_monthly_0.25deg/json.dir/atm2d.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_24h_0.25deg/json.dir/atm3d.json
+  3D_6h_0.25deg:
+    description: 3D 6-hourly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_6h_0.25deg/json.dir/atm3d.json
+  3D_monthly_0.25deg:
+    description: 3D monthly variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_monthly_0.25deg/json.dir/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/main.yaml
@@ -1,0 +1,56 @@
+sources:
+  hist.v20240901.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20240901/atmos/gr025/main.yaml"
+    description: This catalog contains the medium-resolution (tco399, ~ 28km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. 
+    driver: yaml_file_cat
+  hist-c-0-a-lr20.v20240901.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml"
+    description: This catalog contains the medium-resolution (tco399, ~ 28km) EERIE IFS-AMIP *filtered anomalies* historical production run, forced with ESA-CCI v3 SST & sea ice. SST anomalies are filtered with LR20.
+    driver: yaml_file_cat
+  hist-c-lr20-a-0.v20240901.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml"
+    description: This catalog contains the medium-resolution (tco399, ~ 28km) EERIE IFS-AMIP *filtered climatology* historical production run, forced with ESA-CCI v3 SST & sea ice. The daily SST climatology is filtered with LR20.
+    driver: yaml_file_cat
+  hist.v20240304.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20240304/atmos/gr025/main.yaml"
+    description: This catalog contains an EERIE IFS-AMIP historical test experiment with prepIFS CY48r1.0. ESA-CCI v3 SST & sea ice forcing.
+    driver: yaml_file_cat
+  hist.v20231106.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20231106/atmos/gr025/main.yaml"
+    description: This catalog contains an EERIE IFS-AMIP historical test experiment with prepIFS CY48r1.0. OSTIA SST & sea ice forcing.
+    driver: yaml_file_cat
+  hist.v20231006.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20231006/atmos/gr025/main.yaml"
+    description: This catalog contains an EERIE IFS-AMIP test experiment with NextGEMS cycle3 configuration. OSTIA SST & sea ice forcing. Constant 2020 forcing (except SST).
+    driver: yaml_file_cat
+  hist-c-0-a-lr30.v20240304.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-0-a-lr30/v20240304/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-esav3-c-0-a-lr30 test experiment with prepIFS CY48r1.0. ESA-CCI v3 SST (LR30 smoothed anomalies) and new EERIE configuration 
+    driver: yaml_file_cat
+  hist-c-0-a-lr30.v20231106.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-0-a-lr30/v20231106/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs-lr30 test experiment with prepIFS CY48r1.0. smoothed OSTIA SST anomalies and new EERIE configuration 
+    driver: yaml_file_cat
+  hist-c-0-a-lr30.v20231006.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-0-a-lr30/v20231006/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs-lr30 test experiment with NextGEMS cycle3 configuration. smoothed OSTIA SST anomalies
+    driver: yaml_file_cat
+  hist-c-lr30-a-0.v20231106.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-lr30-a-0/v20231106/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs-c-lr30-a-0 test experiment with prepIFS CY48r1.0 - smoothed OSTIA SST climatology and new EERIE configuration 
+    driver: yaml_file_cat
+  hist-c-lr30-a-lr30.v20231106.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist-c-lr30-a-lr30/v20231106/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs-c-lr30-a-lr30 test experiment with prepIFS CY48r1.0 - smoothed OSTIA SST climatology & anomalies, and new EERIE configuration 
+    driver: yaml_file_cat

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
@@ -1,11 +1,11 @@
 sources:
   # 2D_const_0.25deg:
-    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
-    driver: zarr
-    args:
-      consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly_0.25deg:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_0.25deg:
+  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_0.25deg:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
@@ -144,144 +144,144 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
-  # 2D_24h_0.25deg:
-  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
   # 2D_6h_0.25deg:
   #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
@@ -432,56 +432,56 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
-  # 3D_24h_0.25deg:
-  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
   # 3D_6h_0.25deg:
   #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-lr20-a-0/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-lr20-a-0/atmos/gr025/main.yaml
@@ -1,11 +1,11 @@
 sources:
   # 2D_const_0.25deg:
-    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
-    driver: zarr
-    args:
-      consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_const.json
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly_0.25deg:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-lr20-a-0/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-lr20-a-0/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_0.25deg:
+  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_0.25deg:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2014/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2015/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2016/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2017/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2018/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2019/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2020/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2021/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2022/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-lr20-a-0/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist-c-lr20-a-0/atmos/gr025/main.yaml
@@ -144,144 +144,144 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_min.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm2d_max.json
-  # 2D_24h_0.25deg:
-  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
   # 2D_6h_0.25deg:
   #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
@@ -432,56 +432,56 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2021/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2022/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clmn/jsons.2023/atm3d_avg.json
-  # 3D_24h_0.25deg:
-  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d_avg.json
   # 3D_6h_0.25deg:
   #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist/atmos/gr025/main.yaml
@@ -144,144 +144,144 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
-  # 2D_24h_0.25deg:
-  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
   # 2D_6h_0.25deg:
   #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
@@ -432,56 +432,56 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
-  # 3D_24h_0.25deg:
-  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
   # 3D_6h_0.25deg:
   #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_0.25deg:
+  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_0.25deg:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_28-production-hist/atmos/gr025/main.yaml
@@ -1,11 +1,11 @@
 sources:
   # 2D_const_0.25deg:
-    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
-    driver: zarr
-    args:
-      consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly_0.25deg:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
@@ -72,30 +72,30 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_min.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_max.json
@@ -144,144 +144,144 @@ sources:
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
-  # 2D_24h_0.25deg:
-  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
   # 2D_6h_0.25deg:
   #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
@@ -408,14 +408,14 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm3d_avg.json
@@ -432,56 +432,56 @@ sources:
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
-  # 3D_24h_0.25deg:
-  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
   # 3D_6h_0.25deg:
   #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
@@ -1,11 +1,11 @@
 sources:
   # 2D_const_0.25deg:
-    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
-    driver: zarr
-    args:
-      consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly_0.25deg:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist-c-0-a-lr20/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_0.25deg:
+  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.1999/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2000/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2001/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2002/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2003/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2004/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2005/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2006/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2007/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2008/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2009/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2010/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2011/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2012/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2013/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_0.25deg:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist/atmos/gr025/main.yaml
@@ -1,11 +1,11 @@
 sources:
   # 2D_const_0.25deg:
-    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
-    driver: zarr
-    args:
-      consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly_0.25deg:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist/atmos/gr025/main.yaml
@@ -1,0 +1,1217 @@
+sources:
+  # 2D_const_0.25deg:
+    description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  2D_monthly_0.25deg:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_0.25deg:
+  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_0.25deg:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
+  # 2D_6h_0.25deg_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
+  3D_monthly_0.25deg:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_0.25deg:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_0.25deg:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json
+  # 2D_const_native:
+  #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_const.json
+  # 2D_monthly_native:
+  #   description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_max.json
+  # 2D_24h_native:
+  #   description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_max.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_min.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_max.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_min.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_max.json
+  # 2D_6h_native:
+  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d.json
+  # 2D_6h_native_acc:
+  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_acc.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_acc.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_acc.json
+  # 3D_monthly_native:
+  #   description: 3D monthly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm3d_avg.json
+  # 3D_24h_native:
+  #   description: 3D 24-hourly average variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm3d_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm3d_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm3d_avg.json
+  # 3D_6h_native:
+  #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm3d.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm3d.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm3d.json
+  # 2D_monthly_wam:
+  #   description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clmn/jsons.2023/atm2d_ll_avg.json
+  # 2D_24h_wam:
+  #   description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_ll_avg.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_ll_avg.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_ll_avg.json
+  # 2D_6h_wam:
+  #   description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath:
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1980/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1981/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1982/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1983/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1984/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1985/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1986/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1987/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1988/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1989/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1990/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1991/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1992/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1993/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1994/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1995/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1996/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1997/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1998/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.1999/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2000/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2001/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2002/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2003/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2004/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2005/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2006/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2007/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2008/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2009/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2010/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2011/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2012/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2013/atm2d_ll.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2014/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2015/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2016/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2017/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2018/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2019/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2020/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2021/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2022/atm2d_ll.json
+  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/native/clte/jsons.2023/atm2d_ll.json

--- a/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/IFS_9-production-hist/atmos/gr025/main.yaml
@@ -117,171 +117,171 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_min.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
-  # 2D_24h_0.25deg:
-  #   description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
+  2D_24h_0.25deg:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
   # 2D_6h_0.25deg:
   #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
@@ -423,65 +423,65 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2012/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2013/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2014/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
-  # 3D_24h_0.25deg:
-  #   description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
+  3D_24h_0.25deg:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
   # 3D_6h_0.25deg:
   #   description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr

--- a/dkrz/disk/model-output/ifs-amip/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip/main.yaml
@@ -1,4 +1,29 @@
 sources:
+  IFS_9-production-hist:
+    args:
+      path: "{{CATALOG_DIR}}/IFS_9-production-hist/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs output available at DKRZ disk - OSTIA SST and new EERIE configuration 
+    driver: yaml_file_cat
+  IFS_28-production-hist:
+    args:
+      path: "{{CATALOG_DIR}}/IFS_28-production-hist/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs output available at DKRZ disk - OSTIA SST and new EERIE configuration 
+    driver: yaml_file_cat
+  IFS_9-production-hist-c-0-a-lr20:
+    args:
+      path: "{{CATALOG_DIR}}/IFS_9-production-hist-c-0-a-lr20/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs output available at DKRZ disk - OSTIA SST and new EERIE configuration 
+    driver: yaml_file_cat
+  IFS_28-production-hist-c-0-a-lr20:
+    args:
+      path: "{{CATALOG_DIR}}/IFS_28-production-hist-c-0-a-lr20/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs output available at DKRZ disk - OSTIA SST and new EERIE configuration 
+    driver: yaml_file_cat
+  IFS_28-production-hist-c-lr20-a-0:
+    args:
+      path: "{{CATALOG_DIR}}/IFS_28-production-hist-c-lr20-a-0/atmos/gr025/main.yaml"
+    description: This catalog contains EERIE IFS-AMIP amip-hist-obs output available at DKRZ disk - OSTIA SST and new EERIE configuration 
+    driver: yaml_file_cat
   amip-hist-obs.atmos.gr025:
     args:
       path: "{{CATALOG_DIR}}/amip-hist-obs/atmos/gr025/main.yaml"

--- a/dkrz/disk/model-output/main.yaml
+++ b/dkrz/disk/model-output/main.yaml
@@ -9,6 +9,16 @@ sources:
       path: "{{CATALOG_DIR}}/ifs-fesom2-sr/main.yaml"
     description: IFS-FESOM2 output available on DKRZ's Levante File System. This catalog contains datasets for all raw data in /work/bm1344 and accesses the data via kerchunks in /work/bm1344/DKRZ/kerchunks
     driver: yaml_file_cat
+  ifs-amip-tco1279:
+    args:
+      path: "{{CATALOG_DIR}}/ifs-amip-tco1279/main.yaml"
+    description: High-resolution (tco1279, ~ 9km) IFS-AMIP output available on DKRZ's Levante File System. This catalog contains datasets for data in /work/bk1377
+    driver: yaml_file_cat
+  ifs-amip-tco399:
+    args:
+      path: "{{CATALOG_DIR}}/ifs-amip-tco399/main.yaml"
+    description: Medium-resolution (tco399, ~ 28 km) IFS-AMIP output available on DKRZ's Levante File System. This catalog contains datasets for data in /work/bk1377
+    driver: yaml_file_cat
   ifs-amip:
     args:
       path: "{{CATALOG_DIR}}/ifs-amip/main.yaml"


### PR DESCRIPTION
Add EERIE IFS-AMIP production runs, and re-order IFS-AMIP experiments to align with the expected structure of the intake catalogues.
The 5 production runs are indicated by version v20240901, September being the closest to them being run/completed. Not all runs were started or completed at the same time. 
All production runs use the ifs-bundle tag DE_CY48R1.0_EERIE_20240726.

At the moment, the available data for the production runs is
- 1/4 degree monthly means (all variables, levels, only one (out of five) ensemble member of the tco399 runs)
- 1/4 degree daily means (selected variables & levels, only one (out of five) ensemble member of the tco399 runs)

Further data will be added as requested and as space on DKRZ allows. 