### PR TITLE
Update IFS-AMIP catalogues

### DIFF
--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -23,107 +23,239 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24h.parq
-  # 2D_6h:
-  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
-  # 2D_6h_0.25deg_acc:
-  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  2D_6h:
+    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+  2D_6h_acc:
+    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -141,7 +273,51 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -150,4 +326,48 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -201,9 +201,9 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
   2D_6h_acc:

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -203,7 +203,7 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
   2D_6h_acc:

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -164,48 +164,48 @@ sources:
       urlpath:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -164,11 +164,11 @@ sources:
       urlpath:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -194,13 +194,13 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -169,19 +169,19 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -203,9 +203,9 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -182,18 +182,18 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
@@ -23,107 +23,239 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
-  # 2D_6h:
-  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
-  # 2D_6h_0.25deg_acc:
-  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
-  #     # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+  2D_6h:
+    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
+  2D_6h_0.25deg_acc:
+    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -141,7 +273,51 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -150,4 +326,48 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1981/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1982/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1983/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1984/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1985/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1986/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1987/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1988/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1989/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1990/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1991/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1992/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1993/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1994/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1995/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1996/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1997/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1998/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1999/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
@@ -206,7 +206,7 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
-  2D_6h_0.25deg_acc:
+  2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -17,107 +17,239 @@ sources:
     driver: zarr
     args:
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24h.parq
-  # 2D_6h:
-  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
-  # 2D_6h_0.25deg_acc:
-  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_max.json
+  2D_6h:
+    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d.json
+  2D_6h_acc:
+    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm2d_acc.json
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -129,10 +261,98 @@ sources:
     driver: zarr
     args:
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d_avg.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d_avg.json
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1981/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1982/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1983/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1984/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1985/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1986/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1987/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1988/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1989/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1990/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1991/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1992/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1993/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1994/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1995/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1996/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1997/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1998/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1999/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2000/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2001/atm3d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2002/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2003/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2004/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2005/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2006/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2007/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2008/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2009/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2010/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2011/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2012/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2013/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2014/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2015/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2016/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2017/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2018/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2019/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2020/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2021/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2022/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.2023/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
@@ -152,136 +152,136 @@ sources:
       urlpath:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_avg.json
       # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_min.json
-      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
@@ -195,193 +195,193 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
-  # 2D_6h:
-  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d.json
-  # 2D_6h_0.25deg_acc:
-  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_min.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_max.json
+  2D_6h:
+    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d.json
+  2D_6h_acc:
+    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1981/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1982/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1983/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1984/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1985/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1986/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1987/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1988/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1989/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1990/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1991/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm2d_acc.json
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -453,35 +453,35 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d_avg.json
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -503,32 +503,32 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1992/atm3d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1993/atm3d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1994/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1995/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1996/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1997/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1998/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1999/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2000/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2001/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2002/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2003/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2004/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2005/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2006/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2007/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2008/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2009/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2010/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2011/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2012/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2013/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2014/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2015/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2016/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2017/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2018/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2019/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2020/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2021/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2022/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.2023/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
@@ -152,236 +152,236 @@ sources:
       urlpath:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
+      # # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
       # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
-  # 2D_6h:
-  #   description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
-  # 2D_6h_0.25deg_acc:
-  #   description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
-  #   driver: zarr
-  #   args:
-  #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
+  2D_6h:
+    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
+  2D_6h_acc:
+    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath:
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
+      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -458,30 +458,30 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -508,27 +508,27 @@ sources:
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d.json
       - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
+      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json


### PR DESCRIPTION
- Add 6h output
- tco399 catalogues not complete (until early 2000s) - to be updated