### PR TITLE
IFS-AMIP catalogues to parquets in bk1377 

### DIFF
--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -13,7 +13,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
@@ -22,7 +22,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
@@ -31,7 +31,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true         
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
@@ -40,7 +40,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true            
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
@@ -49,7 +49,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
@@ -58,7 +58,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
@@ -67,5 +67,5 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -14,7 +14,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -23,7 +23,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -32,7 +32,7 @@ sources:
         remote_protocol: file
         lazy: true         
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -41,7 +41,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -50,7 +50,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -59,7 +59,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -68,4 +68,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
@@ -14,7 +14,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -23,7 +23,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
@@ -32,7 +32,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
     driver: zarr
@@ -41,7 +41,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_native_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on the native grid
     driver: zarr
@@ -50,7 +50,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on the native grid
     driver: zarr
@@ -59,7 +59,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
@@ -68,7 +68,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_6h.parq
   2D_monthly_wam:
     description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
@@ -77,7 +77,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly_wam.parq
   2D_24h_wam:
     description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
@@ -86,7 +86,7 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h_wam:
     description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
@@ -95,4 +95,4 @@ sources:
         lazy: true
         remote_protocol: file
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_wam.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -13,7 +13,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
@@ -22,7 +22,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
@@ -31,7 +31,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
@@ -40,7 +40,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on the native grid
@@ -49,7 +49,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on the native grid
@@ -58,7 +58,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
@@ -67,7 +67,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/3D_6h.parq
   2D_monthly_wam:
     description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
@@ -76,7 +76,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly_wam.parq
   2D_24h_wam:
     description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
@@ -85,7 +85,7 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h_wam:
     description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
@@ -94,5 +94,5 @@ sources:
       storage_options:
         lazy: true
         remote_protocol: file
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_wam.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
@@ -4,106 +4,23 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: true
+        lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2023/atm2d_avg.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1980/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1981/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1982/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1983/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1984/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1985/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1986/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1987/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1988/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1989/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1990/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1991/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1992/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1993/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1994/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1995/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1996/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1997/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1998/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1999/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2000/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2001/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2002/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2003/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2004/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2005/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2006/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2007/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2008/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2009/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2010/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2011/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2012/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2013/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2014/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2015/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2016/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2017/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2018/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2019/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2020/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2021/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2022/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2023/atm2d_ll.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/2D_6h.parq
+

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
@@ -4,23 +4,26 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist-c-0-a-lr20/v20240901/wave/gr025/2D_6h.parq
 

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
@@ -14,7 +14,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -23,7 +23,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -32,7 +32,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -41,7 +41,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -50,7 +50,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -59,7 +59,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -68,4 +68,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -13,7 +13,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
@@ -22,7 +22,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
@@ -31,7 +31,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true            
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
@@ -40,7 +40,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true            
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
@@ -49,7 +49,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
@@ -58,7 +58,7 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
@@ -67,5 +67,5 @@ sources:
       storage_options:
         remote_protocol: file
         lazy: true
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
@@ -5,7 +5,7 @@ sources:
   #   args:
   #     consolidated: False
   #     urlpath:
-  #     - reference:://work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
@@ -14,7 +14,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -23,7 +23,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -32,7 +32,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -41,7 +41,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -50,7 +50,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -59,7 +59,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -68,4 +68,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/gr025/main.yaml
@@ -5,7 +5,7 @@ sources:
   #   args:
   #     consolidated: False
   #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
+  #     - reference:://work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
@@ -14,7 +14,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -23,7 +23,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -32,7 +32,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -41,7 +41,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -50,7 +50,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -59,7 +59,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -68,4 +68,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/main.yaml
@@ -28,7 +28,7 @@ sources:
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_6h.parq
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
-  2D_6h_native_acc:
+  2D_6h_acc:
     args:
       storage_options:
         remote_protocol: file

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/main.yaml
@@ -5,7 +5,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_24h.parq
     description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily
       averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -15,7 +15,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_24h_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_24h_wam.parq
     description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM)
       grid
     driver: zarr
@@ -25,7 +25,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_6h.parq
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
   2D_6h_native_acc:
@@ -34,7 +34,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_6h_native_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_6h_acc.parq
     description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
     driver: zarr
   2D_6h_wam:
@@ -43,7 +43,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_6h_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_6h_wam.parq
     description: 6-hourly instantaneous variables from IFS-AMIP on the native wave
       model (WAM) grid
     driver: zarr
@@ -53,7 +53,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_monthly.parq
     description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly
       averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
@@ -63,7 +63,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_monthly_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/2D_monthly_wam.parq
     description: 2D monthly mean variables from IFS-AMIP on the native wave model
       (WAM) grid
     driver: zarr
@@ -73,7 +73,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/3D_24h.parq
     description: 3D 24-hourly average variables from IFS-AMIP on the native grid
     driver: zarr
   3D_6h:
@@ -82,7 +82,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/3D_6h.parq
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
   3D_monthly:
@@ -91,6 +91,6 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/atmos/native/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/atmos/native/3D_monthly.parq
     description: 3D monthly average variables from IFS-AMIP on the native grid
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/wave/gr025/main.yaml
@@ -4,23 +4,26 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/wave/gr025/2D_6h.parq
 

--- a/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/wave/gr025/main.yaml
@@ -6,104 +6,21 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco1279/hist/v20240901/wave/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2023/atm2d_avg.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1980/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1981/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1982/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1983/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1984/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1985/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1986/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1987/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1988/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1989/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1990/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1991/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1992/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1993/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1994/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1995/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1996/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1997/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1998/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.1999/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2000/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2001/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2002/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2003/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2004/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2005/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2006/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2007/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2008/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2009/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2010/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2011/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2012/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2013/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2014/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2015/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2016/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2017/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2018/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2019/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2020/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2021/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2022/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco1279-eerie_production_202407/latlon/wave/clte/jsons.2023/atm2d_ll.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco1279/hist/v20240901/wave/gr025/2D_6h.parq
+

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -13,7 +13,7 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -21,7 +21,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -29,13 +29,13 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -51,7 +51,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -59,4 +59,4 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -5,7 +5,7 @@ sources:
   #   args:
   #     consolidated: False
   #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  #     - reference:://work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
@@ -13,7 +13,7 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -21,7 +21,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -29,13 +29,13 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -51,7 +51,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -59,4 +59,4 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -11,52 +11,58 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/main.yaml
@@ -5,7 +5,7 @@ sources:
   #   args:
   #     consolidated: False
   #     urlpath:
-  #     - reference:://work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
+  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
@@ -13,7 +13,7 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -21,7 +21,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -29,13 +29,13 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -51,7 +51,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -59,4 +59,4 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -11,78 +11,88 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_6h.parq
   2D_monthly_wam:
     description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly_wam.parq
   2D_24h_wam:
     description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h_wam:
     description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
       storage_options:
-        lazy: True            
-      consolidated: False
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_wam.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/main.yaml
@@ -13,139 +13,7 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_max.json
-      #- reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_avg.json
-      #- reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_min.json
-      #- reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_max.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -153,139 +21,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_max.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_avg.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_min.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_max.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
@@ -293,51 +29,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
     driver: zarr
@@ -345,51 +37,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_acc.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_acc.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_acc.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on the native grid
     driver: zarr
@@ -397,51 +45,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_monthly.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm3d_avg.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm3d_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on the native grid
     driver: zarr
@@ -449,51 +53,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_24h.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d_avg.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
@@ -501,51 +61,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_6h.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm3d.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm3d.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/3D_6h.parq
   2D_monthly_wam:
     description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
@@ -553,51 +69,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly_wam.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1980/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1981/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1982/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1983/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1984/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1985/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1986/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1987/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1988/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1989/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1990/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1991/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1992/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1993/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1994/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1995/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1996/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1997/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1998/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.1999/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2000/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2001/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2002/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2003/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2004/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2005/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2006/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2007/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2008/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2009/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2010/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2011/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2012/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2013/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2014/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2015/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2016/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2017/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2018/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2019/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2020/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2021/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2022/atm2d_ll_avg.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clmn/jsons.2023/atm2d_ll_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_monthly_wam.parq
   2D_24h_wam:
     description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
@@ -605,51 +77,7 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h_wam.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll_avg.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h_wam:
     description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
@@ -657,48 +85,4 @@ sources:
       storage_options:
         lazy: True            
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_wam.parq
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1980/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1981/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1982/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1983/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1984/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1985/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1986/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1987/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1988/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1989/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1990/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1991/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1992/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1993/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1994/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1995/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1996/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1997/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1998/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.1999/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2000/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2001/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2002/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2003/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2004/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2005/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2006/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2007/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2008/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2009/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2010/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2011/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2012/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2013/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2014/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2015/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2016/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2017/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2018/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2019/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2020/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2021/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2022/atm2d_ll.json
-      #      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/native/clte/jsons.2023/atm2d_ll.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/atmos/native/2D_6h_wam.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
@@ -4,23 +4,26 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/2D_6h.parq
 

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/main.yaml
@@ -6,104 +6,21 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2023/atm2d_avg.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1980/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1981/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1982/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1983/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1984/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1985/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1986/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1987/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1988/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1989/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1990/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1991/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1992/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1993/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1994/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1995/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1996/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1997/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1998/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.1999/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2000/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2001/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2002/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2003/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2004/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2005/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2006/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2007/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2008/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2009/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2010/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2011/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2012/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2013/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2014/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2015/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2016/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2017/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2018/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2019/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2020/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2021/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2022/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_0_a_LR20/latlon/wave/clte/jsons.2023/atm2d_ll.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-0-a-lr20/v20240901/wave/gr025/2D_6h.parq
+

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/gr025/main.yaml
@@ -100,7 +100,7 @@ sources:
   2D_6h_native:
     args:
       storage_options:
-        lazy: True
+        lazy: true
       consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/gr025/2D_6h_native.parq
     description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/native/main.yaml
@@ -2,7 +2,8 @@ sources:
   2D_6h:
     args:
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20231106/atmos/native/2D_6h.parq
     description: 2D 6-hourly variables from IFS-AMIP on native tco399 grid

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/main.yaml
@@ -3,61 +3,68 @@ sources:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/2D_24h.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
   2D_6h:
     description: 2D 6-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/2D_6h.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
   2D_6h_native:
     description: 2D 6-hourly variables from IFS-AMIP on native grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/2D_6h_native.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
   2D_const:
     description: 2D constant variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_lr30/gribscan/2D_const_0.25deg/json.dir/atm2d.json
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/2D_monthly.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
   3D_24h:
     description: 3D 24-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/3D_24h.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
   3D_6h:
     description: 3D 6-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/3D_6h.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
   3D_monthly:
     description: 3D monthly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/gr025/3D_monthly.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/native/main.yaml
@@ -4,6 +4,7 @@ sources:
       consolidated: false
       urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-0-a-lr30/v20240304/atmos/native/2D_6h.parq
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
     description: 2D 6-hourly variables from IFS-AMIP on native grid
     driver: zarr

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -11,54 +11,61 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/main.yaml
@@ -13,7 +13,7 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -21,7 +21,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -29,7 +29,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -37,7 +37,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_6h_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -45,7 +45,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -53,7 +53,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -61,4 +61,4 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly_wam:
@@ -11,78 +11,88 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_monthly_wam.parq
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_24h.parq
   2D_24h_wam:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h.parq
   2D_6h_wam:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h_wam.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/main.yaml
@@ -13,7 +13,7 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_monthly_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_monthly_wam.parq
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
@@ -21,7 +21,7 @@ sources:
       storage_options:
         lazy: True
       consolidated: False
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -29,7 +29,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_24h.parq
   2D_24h_wam:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -37,7 +37,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_24h_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -45,7 +45,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h.parq
   2D_6h_wam:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -53,7 +53,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h_wam.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h_wam.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -61,7 +61,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h_acc.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -69,7 +69,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_monthly.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -77,7 +77,7 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_24h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -85,4 +85,4 @@ sources:
       consolidated: False
       storage_options:
         lazy: True
-      urlpath: reference:://work/bm1344/DKRZ/intake_catalogues/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_6h.parq
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/atmos/native/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/main.yaml
@@ -4,23 +4,26 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/2D_6h.parq
 

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/main.yaml
@@ -3,149 +3,24 @@ sources:
     description: 2D monthly mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1980/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1981/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1982/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1983/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1984/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1985/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1986/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1987/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1988/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1989/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1990/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1991/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1992/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1993/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1994/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1995/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1996/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1997/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1998/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.1999/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2000/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2001/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2002/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2003/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2004/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2005/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2006/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2007/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2008/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2009/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2010/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2011/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2012/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2013/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2014/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2015/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2016/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2017/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2018/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2019/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2020/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2021/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2022/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clmn/jsons.2023/atm2d_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2023/atm2d_avg.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1980/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1981/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1982/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1983/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1984/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1985/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1986/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1987/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1988/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1989/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1990/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1991/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1992/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1993/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1994/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1995/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1996/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1997/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1998/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.1999/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2000/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2001/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2002/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2003/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2004/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2005/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2006/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2007/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2008/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2009/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2010/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2011/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2012/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2013/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2014/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2015/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2016/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2017/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2018/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2019/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2020/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2021/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2022/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202408-c_LR20_a_0/latlon/wave/clte/jsons.2023/atm2d_ll.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist-c-lr20-a-0/v20240901/wave/gr025/2D_6h.parq
+

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240304/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240304/atmos/gr025/main.yaml
@@ -3,47 +3,47 @@ sources:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_24h_0.25deg/json.dir/atm2d.json
   2D_6h:
     description: 2D 6-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_6h_0.25deg/json.dir/atm2d.json
   2D_6h_native:
     description: 2D 6-hourly variables from IFS-AMIP on native grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_6h_native/json.dir/atm2d.json
   2D_const:
     description: 2D constant variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_const_0.25deg/json.dir/atm2d.json
   2D_monthly:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/2D_monthly_0.25deg/json.dir/atm2d.json
   3D_24h:
     description: 3D 24-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_24h_0.25deg/json.dir/atm3d.json
   3D_6h:
     description: 3D 6-hourly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_6h_0.25deg/json.dir/atm3d.json
   3D_monthly:
     description: 3D monthly variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/prepIFS/ESAv3/ESAv3_c_0_a_0/gribscan/3D_monthly_0.25deg/json.dir/atm3d.json

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
@@ -10,525 +10,55 @@ sources:
     description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm2d_max.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_max.json
+      storage_options:
+        lazy: True
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d.json
+      storage_options:
+        lazy: True
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm2d_acc.json
+      storage_options:
+        lazy: True
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1980/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1981/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1982/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1983/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1984/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1985/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1986/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1987/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1988/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1989/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1990/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1991/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1992/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1993/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1994/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1995/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1996/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1997/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1998/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.1999/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2000/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2001/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2002/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2003/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2004/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2005/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2006/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2007/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2008/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2009/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2010/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2011/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2012/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2013/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2014/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2015/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2016/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2017/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2018/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2019/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2020/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2021/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2022/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clmn/jsons.2023/atm3d_avg.json
+      storage_options:
+        lazy: True
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d_avg.json
+      storage_options:
+        lazy: True
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1981/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1982/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1983/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1984/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1985/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1986/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1987/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1988/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1989/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1990/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1991/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1992/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1993/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1994/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1995/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1996/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1997/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1998/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1999/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2000/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2001/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2002/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2003/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2004/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2005/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2006/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2007/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2008/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2009/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2010/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2011/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2012/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2013/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2014/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2015/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2016/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2017/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2018/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2019/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2020/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2021/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2022/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.2023/atm3d.json
+      storage_options:
+        lazy: True
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/gr025/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -11,54 +11,61 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
-      consolidated: False
+      consolidated: false
       storage_options:
-        lazy: True
+        remote_protocol: file
+        lazy: true
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/gr025/3D_6h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/native/main.yaml
@@ -10,675 +10,79 @@ sources:
     description: 2D monthly variables from IFS-AMIP on the native grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_max.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_max.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_min.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_max.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_min.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_max.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_acc.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_acc.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_acc.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on the native grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm3d_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on the native grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm3d_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm3d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm3d_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm3d.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm3d.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm3d.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/3D_6h.parq
   2D_monthly_wam:
     description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1980/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1981/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1982/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1983/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1984/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1985/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1986/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1987/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1988/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1989/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1990/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1991/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1992/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1993/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1994/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1995/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1996/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1997/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1998/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.1999/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2000/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2001/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2002/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2003/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2004/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2005/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2006/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2007/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2008/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2009/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2010/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2011/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2012/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2013/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2014/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2015/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2016/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2017/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2018/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2019/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2020/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2021/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2022/atm2d_ll_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clmn/jsons.2023/atm2d_ll_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_monthly_wam.parq
   2D_24h_wam:
     description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_ll_avg.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_ll_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_ll_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h_wam:
     description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1981/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1982/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1983/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1984/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1985/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1986/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1987/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1988/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1989/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1990/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1991/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1992/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1993/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1994/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1995/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1996/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1997/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1998/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1999/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2000/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2001/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2002/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2003/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2004/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2005/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2006/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2007/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2008/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2009/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2010/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2011/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2012/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2013/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2014/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2015/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2016/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2017/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2018/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2019/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2020/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2021/atm2d_ll.json
-      # - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2022/atm2d_ll.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.2023/atm2d_ll.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_6h_wam.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/atmos/native/main.yaml
@@ -3,7 +3,7 @@ sources:
   #   description: 2D constant variables from IFS-AMIP on 0.25 degree grid
   #   driver: zarr
   #   args:
-  #     consolidated: False
+  #     consolidated: false
   #     urlpath:
   #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/native/clte/jsons.1980/atm2d_const.json
   2D_monthly:
@@ -11,78 +11,88 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on the native grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_24h.parq
   2D_6h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_6h.parq
   2D_6h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_6h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/3D_24h.parq
   3D_6h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on the native grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/3D_6h.parq
   2D_monthly_wam:
     description: 2D monthly mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_monthly_wam.parq
   2D_24h_wam:
     description: 2D daily mean variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_24h_wam.parq
   2D_6h_wam:
     description: 6-hourly instantaneous variables from IFS-AMIP on the native wave model (WAM) grid
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/atmos/native/2D_6h_wam.parq

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/wave/gr025/main.yaml
@@ -3,149 +3,24 @@ sources:
     description: 2D monthly mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
     driver: zarr
     args:
+      storage_options:
+        lazy: True
       consolidated: False
-      urlpath:
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1980/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1981/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1982/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1983/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1984/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1985/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1986/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1987/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1988/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1989/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1990/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1991/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1992/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1993/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1994/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1995/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1996/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1997/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1998/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.1999/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2000/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2001/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2002/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2003/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2004/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2005/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2006/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2007/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2008/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2009/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2010/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2011/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2012/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2013/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2014/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2015/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2016/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2017/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2018/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2019/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2020/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2021/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2022/atm2d_avg.json
-      - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clmn/jsons.2023/atm2d_avg.json
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1980/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1981/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1982/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1983/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1984/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1985/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1986/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1987/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1988/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1989/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1990/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1991/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1992/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1993/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1994/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1995/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1996/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1997/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1998/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1999/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2000/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2001/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2002/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2003/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2004/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2005/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2006/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2007/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2008/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2009/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2010/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2011/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2012/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2013/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2014/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2015/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2016/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2017/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2018/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2019/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2020/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2021/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2022/atm2d_avg.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2023/atm2d_avg.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
+  #     storage_options:
+  #       lazy: True
   #     consolidated: False
-  #     urlpath:
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1980/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1981/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1982/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1983/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1984/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1985/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1986/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1987/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1988/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1989/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1990/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1991/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1992/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1993/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1994/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1995/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1996/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1997/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1998/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.1999/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2000/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2001/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2002/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2003/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2004/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2005/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2006/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2007/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2008/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2009/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2010/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2011/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2012/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2013/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2014/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2015/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2016/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2017/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2018/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2019/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2020/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2021/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2022/atm2d_ll.json
-  #     - reference::/work/bk1377/b382473/IFS_AMIP/production/indices/tco399-eerie_production_202407/latlon/wave/clte/jsons.2023/atm2d_ll.json
+  #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/wave/gr025/2D_6h.parq
+

--- a/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/wave/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco399/hist/v20240901/wave/gr025/main.yaml
@@ -4,23 +4,26 @@ sources:
     driver: zarr
     args:
       storage_options:
-        lazy: True
-      consolidated: False
+        remote_protocol: file
+        lazy: true
+      consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/wave/gr025/2D_monthly.parq
   # 2D_24h:
   #   description: 2D daily mean wave model output from IFS-AMIP on 0.25 regular grid. NOTE - only positive values are valid.
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/wave/gr025/2D_24h.parq
   # 2D_6h:
   #   description: 6-hourly instantaneous wave model output from IFS-AMIP on 0.25 regular grid
   #   driver: zarr
   #   args:
   #     storage_options:
-  #       lazy: True
-  #     consolidated: False
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
   #     urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco399/hist/v20240901/wave/gr025/2D_6h.parq
 


### PR DESCRIPTION
Updates to IFS-AMIP catalogues:
- all production catalogues are now parquets saved in bk1377 project
- monthly means of tco399 runs now include all 10 ensemble members (up from 5)
- some fixes to broken data
- some consistency changes to catalogue arguments (including pre-production catalogues)