### PR TITLE
Add ifs-amip-tco2559 catalogues, 0.25 deg output

### DIFF
--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20240901/atmos/gr025/main.yaml
@@ -1,0 +1,64 @@
+sources:
+  2D_monthly:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_monthly.parq
+  2D_24h:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_24h.parq
+  2D_1h:
+    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_1h.parq
+  2D_1h_acc:
+    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_1h_acc.parq
+  3D_monthly:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_monthly.parq
+  3D_24h:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_24h.parq
+  3D_1h:
+    description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/gr025/main.yaml
@@ -1,0 +1,64 @@
+sources:
+  2D_monthly:
+    description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly.parq
+  2D_24h:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h.parq
+  2D_1h:
+    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h.parq
+  2D_1h_acc:
+    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc.parq
+  3D_monthly:
+    description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_monthly.parq
+  3D_24h:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_24h.parq
+  3D_1h:
+    description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/main.yaml
@@ -1,0 +1,11 @@
+sources:
+  hist.v20240901.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20240901/atmos/gr025/main.yaml"
+    description: This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. Output on regular 0.25 x 0.25 degree grid. 
+    driver: yaml_file_cat
+  hist.v20250101.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20240901/atmos/gr025/main.yaml"
+    description: This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. Output on regular 0.25 x 0.25 degree grid. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat

--- a/dkrz/disk/model-output/main.yaml
+++ b/dkrz/disk/model-output/main.yaml
@@ -9,6 +9,11 @@ sources:
       path: "{{CATALOG_DIR}}/ifs-fesom2-sr/main.yaml"
     description: IFS-FESOM2 output available on DKRZ's Levante File System. This catalog contains datasets for all raw data in /work/bm1344 and accesses the data via kerchunks in /work/bm1344/DKRZ/kerchunks
     driver: yaml_file_cat
+  ifs-amip-tco2559:
+    args:
+      path: "{{CATALOG_DIR}}/ifs-amip-tco2559/main.yaml"
+    description: High-resolution (tco2559, ~ 4.4km) IFS-AMIP output available on DKRZ's Levante File System. Currently only on scratch, not persistent
+    driver: yaml_file_cat
   ifs-amip-tco1279:
     args:
       path: "{{CATALOG_DIR}}/ifs-amip-tco1279/main.yaml"


### PR DESCRIPTION
Add two short (6 and 8 months) IFS-AMIP simulations.
- v20240901: same settings as historical tco1279 and tco399 runs
- v20250101: same settings as historical tco1279 and tco399 runs, except for it using "reduced cloud base mass flux" in line with NextGEMS & DestinE settings

Both are initialised in 2020-01-01. They include hourly output, so the standard 6-hourly catalogues are replaced with 1-hourly ones. Daily means and monthly means are written as usual.