### PR TITLE
Update ifs-amip tco2599 rcbmf run to 14 months. 

### DIFF
--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/gr025/main.yaml
@@ -8,6 +8,15 @@ sources:
         lazy: true
       consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly.parq
+  2D_monthly_extra:
+    description: additional 2D monthly variables from IFS-AMIP on 0.25 degree grid. Monthly averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly_extra.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -17,8 +26,17 @@ sources:
         lazy: true
       consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h.parq
+  2D_24h_extra:
+    description: additional 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Daily averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h_extra.parq
   2D_1h:
-    description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       storage_options:
@@ -26,8 +44,17 @@ sources:
         lazy: true            
       consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h.parq
+  2D_1h_extra:
+    description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_extra.parq
   2D_1h_acc:
-    description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       storage_options:
@@ -35,6 +62,15 @@ sources:
         lazy: true            
       consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc.parq
+  2D_1h_acc_extra:
+    description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc_extra.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -54,7 +90,7 @@ sources:
       consolidated: false
       urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_24h.parq
   3D_1h:
-    description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    description: 3D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
     args:
       storage_options:


### PR DESCRIPTION
With hourly output. Last 6 months with additional output