### PR TITLE
Update tco2559 AMIP

### DIFF
--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20240901/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20240901/atmos/gr025/main.yaml
@@ -7,7 +7,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_monthly.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -16,7 +16,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_24h.parq
   2D_1h:
     description: 2D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -25,7 +25,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_1h.parq
   2D_1h_acc:
     description: 2D 6-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -34,7 +34,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_1h_acc.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/2D_1h_acc.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -52,7 +52,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_24h.parq
   3D_1h:
     description: 3D 6-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -61,4 +61,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bk1377/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20240901/atmos/gr025/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/main.yaml
@@ -7,7 +7,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_monthly.parq
   2D_monthly_extra:
     description: additional 2D monthly variables from IFS-AMIP on 0.25 degree grid. Monthly averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -16,7 +16,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_monthly_extra.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -25,7 +25,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_24h.parq
   2D_24h_extra:
     description: additional 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Daily averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -34,7 +34,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_24h_extra.parq
   2D_1h:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_1h.parq
   2D_1h_extra:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -52,7 +52,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_1h_extra.parq
   2D_1h_acc:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -61,7 +61,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_1h_acc.parq
   2D_1h_acc_extra:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -70,7 +70,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/2D_1h_acc_extra.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -79,7 +79,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -88,7 +88,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/3D_24h.parq
   3D_1h:
     description: 3D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -97,4 +97,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix1024/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/main.yaml
@@ -7,7 +7,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_monthly.parq
   2D_monthly_extra:
     description: additional 2D monthly variables from IFS-AMIP on 0.25 degree grid. Monthly averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -16,7 +16,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_monthly_extra.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -25,7 +25,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_24h.parq
   2D_24h_extra:
     description: additional 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Daily averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -34,7 +34,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_24h_extra.parq
   2D_1h:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_1h.parq
   2D_1h_extra:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -52,7 +52,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_1h_extra.parq
   2D_1h_acc:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -61,7 +61,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_1h_acc.parq
   2D_1h_acc_extra:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -70,7 +70,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/2D_1h_acc_extra.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -79,7 +79,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -88,7 +88,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/3D_24h.parq
   3D_1h:
     description: 3D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -97,4 +97,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix128/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/main.yaml
@@ -7,7 +7,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_monthly.parq
   2D_monthly_extra:
     description: additional 2D monthly variables from IFS-AMIP on 0.25 degree grid. Monthly averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -16,7 +16,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_monthly_extra.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -25,7 +25,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_24h.parq
   2D_24h_extra:
     description: additional 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Daily averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -34,7 +34,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_24h_extra.parq
   2D_1h:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_1h.parq
   2D_1h_extra:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -52,7 +52,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_1h_extra.parq
   2D_1h_acc:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -61,7 +61,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_1h_acc.parq
   2D_1h_acc_extra:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -70,7 +70,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/2D_1h_acc_extra.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -79,7 +79,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -88,7 +88,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/3D_24h.parq
   3D_1h:
     description: 3D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -97,4 +97,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix32/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/main.yaml
@@ -7,7 +7,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_monthly.parq
   2D_monthly_extra:
     description: additional 2D monthly variables from IFS-AMIP on 0.25 degree grid. Monthly averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -16,7 +16,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_monthly_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_monthly_extra.parq
   2D_24h:
     description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
     driver: zarr
@@ -25,7 +25,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_24h.parq
   2D_24h_extra:
     description: additional 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Daily averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
     driver: zarr
@@ -34,7 +34,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_24h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_24h_extra.parq
   2D_1h:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -43,7 +43,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_1h.parq
   2D_1h_extra:
     description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -52,7 +52,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_1h_extra.parq
   2D_1h_acc:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -61,7 +61,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_1h_acc.parq
   2D_1h_acc_extra:
     description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -70,7 +70,7 @@ sources:
         remote_protocol: file
         lazy: true            
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/2D_1h_acc_extra.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/2D_1h_acc_extra.parq
   3D_monthly:
     description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -79,7 +79,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_monthly.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/3D_monthly.parq
   3D_24h:
     description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -88,7 +88,7 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_24h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/3D_24h.parq
   3D_1h:
     description: 3D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
     driver: zarr
@@ -97,4 +97,4 @@ sources:
         remote_protocol: file
         lazy: true
       consolidated: false
-      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/gr025/3D_1h.parq
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/healpix512/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/native/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/hist/v20250101/atmos/native/main.yaml
@@ -1,0 +1,100 @@
+sources:
+  # 2D_monthly:
+  #   description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     storage_options:
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
+  #     urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_monthly.parq
+  # 2D_monthly_extra:
+  #   description: additional 2D monthly variables from IFS-AMIP on 0.25 degree grid. Monthly averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
+  #   driver: zarr
+  #   args:
+  #     storage_options:
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
+  #     urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_monthly_extra.parq
+  2D_24h:
+    description: 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Mostly daily averages, but also mininum (mn2t24) and maximum (mx2t24, 10fg)
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_24h.parq
+  2D_24h_extra:
+    description: additional 2D 24-hourly variables from IFS-AMIP on 0.25 degree grid. Daily averages. Only available for part of the time-period, and data may not correctly encoded as monthly time-means.
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_24h_extra.parq
+  2D_1h:
+    description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_1h.parq
+  2D_1h_extra:
+    description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_1h_extra.parq
+  2D_1h_acc:
+    description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_1h_acc.parq
+  2D_1h_acc_extra:
+    description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/2D_1h_acc_extra.parq
+  # 3D_monthly:
+  #   description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     storage_options:
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
+  #     urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/3D_monthly.parq
+  3D_24h:
+    description: 3D 24-hourly average variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/3D_24h.parq
+  3D_1h:
+    description: 3D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco2559/hist/v20250101/atmos/native/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco2559/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/main.yaml
@@ -2,10 +2,35 @@ sources:
   hist.v20240901.atmos.gr025:
     args:
       path: "{{CATALOG_DIR}}/hist/v20240901/atmos/gr025/main.yaml"
-    description: This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. Output on regular 0.25 x 0.25 degree grid. 
+    description: Output on 0.25 degree regular grid. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. 
     driver: yaml_file_cat
   hist.v20250101.atmos.gr025:
     args:
       path: "{{CATALOG_DIR}}/hist/v20250101/atmos/gr025/main.yaml"
-    description: This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. Output on regular 0.25 x 0.25 degree grid. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    description: Output on 0.25 degree regular grid. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat
+  hist.v20250101.atmos.native:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20250101/atmos/native/main.yaml"
+    description: Output on native model grid. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat
+  hist.v20250101.atmos.healpix32:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20250101/atmos/healpix32/main.yaml"
+    description: Output on HEALPix grid H32. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat
+  hist.v20250101.atmos.healpix128:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20250101/atmos/healpix128/main.yaml"
+    description: Output on HEALPix grid H128. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat
+  hist.v20250101.atmos.healpix512:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20250101/atmos/healpix512/main.yaml"
+    description: Output on HEALPix grid H512. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat
+  hist.v20250101.atmos.healpix1024:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20250101/atmos/healpix1024/main.yaml"
+    description: Output on HEALPix grid H1024. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
     driver: yaml_file_cat


### PR DESCRIPTION
Update catalogues for tco2559 AMIP runs
- add full 14 months for v20250101 (0.25 deg, healpix, a few days of native)
- move data & catalogues to bm1235 for storage availability.