### PR TITLE
Add catalogs for ifs-amip-3999

### DIFF
--- a/dkrz/disk/model-output/ifs-amip-tco2559/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco2559/main.yaml
@@ -17,5 +17,5 @@ sources:
   hist.v20250101.atmos.healpix:
     args:
       path: "{{CATALOG_DIR}}/hist/v20250101/atmos/healpix/main.yaml"
-    description: Output on HEALPix grid, on zoom levels 5, 7, 9 and 10, corresponding to grids H32, H128, H512 and H1024, with resolutions approximately 203.7 km, 50,9 km, 12.7 km and 6.4 km. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
+    description: Output on HEALPix grid, on zoom levels 5, 7, 9 and 10, corresponding to grids H32, H128, H512 and H1024, with resolutions approximately 203.7 km, 50.9 km, 12.7 km and 6.4 km. This catalog contains the high-resolution (tco2559, ~4.4km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. The difference to v20240901 is that v20250101 uses "reduced cloud-base mass flux".
     driver: yaml_file_cat

--- a/dkrz/disk/model-output/ifs-amip-tco3999/hist/v20250101/atmos/gr025/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco3999/hist/v20250101/atmos/gr025/main.yaml
@@ -1,0 +1,46 @@
+sources:
+  # 2D_monthly:
+  #   description: 2D monthly variables from IFS-AMIP on 0.25 degree grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     storage_options:
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
+  #     urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/gr025/2D_monthly.parq
+  2D_1h:
+    description: 2D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/gr025/2D_1h.parq
+  2D_1h_acc:
+    description: 2D 1-hourly accumulated variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/gr025/2D_1h_acc.parq
+  # 3D_monthly:
+  #   description: 3D monthly average variables from IFS-AMIP on 0.25 degree grid
+  #   driver: zarr
+  #   args:
+  #     storage_options:
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
+  #     urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/gr025/3D_monthly.parq
+  3D_1h:
+    description: 3D 1-hourly instantaneous variables from IFS-AMIP on 0.25 degree grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/gr025/3D_1h.parq

--- a/dkrz/disk/model-output/ifs-amip-tco3999/hist/v20250101/atmos/healpix/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco3999/hist/v20250101/atmos/healpix/main.yaml
@@ -1,0 +1,86 @@
+sources:
+  # 2D_monthly:
+  #   description: 2D monthly variables from IFS-AMIP on HEALPix grid. Mostly monthly averages, but also mininum (mn2t) and maximum (mx2t, 10fg)
+  #   driver: zarr
+  #   args:
+  #     storage_options:
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
+  #     urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/healpix_z{{ zoom }}/2D_monthly.parq
+  #   parameters:
+  #     zoom:
+  #       allowed:
+  #       - 7
+  #       - 11
+  #       default: 7
+  #       description: healpix zoom level of dataset
+  #       type: int
+  2D_1h:
+    description: 2D 1-hourly instantaneous variables from IFS-AMIP on HEALPix grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/healpix_z{{ zoom }}/2D_1h.parq
+    parameters:
+      zoom:
+        allowed:
+        - 7
+        - 11
+        default: 7
+        description: healpix zoom level of dataset
+        type: int
+  2D_1h_acc:
+    description: 2D 1-hourly accumulated variables from IFS-AMIP on HEALPix grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true            
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/healpix_z{{ zoom }}/2D_1h_acc.parq
+    parameters:
+      zoom:
+        allowed:
+        - 7
+        - 11
+        default: 7
+        description: healpix zoom level of dataset
+        type: int
+  # 3D_monthly:
+  #   description: 3D monthly average variables from IFS-AMIP on HEALPix grid
+  #   driver: zarr
+  #   args:
+  #     storage_options:
+  #       remote_protocol: file
+  #       lazy: true
+  #     consolidated: false
+  #     urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/healpix_z{{ zoom }}/3D_monthly.parq
+  #   parameters:
+  #     zoom:
+  #       allowed:
+  #       - 7
+  #       - 11
+  #       default: 7
+  #       description: healpix zoom level of dataset
+  #       type: int
+  3D_1h:
+    description: 3D 1-hourly instantaneous variables from IFS-AMIP on HEALPix grid
+    driver: zarr
+    args:
+      storage_options:
+        remote_protocol: file
+        lazy: true
+      consolidated: false
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/ifs-amip-tco3999/hist/v20250101/atmos/healpix_z{{ zoom }}/3D_1h.parq
+    parameters:
+      zoom:
+        allowed:
+        - 7
+        - 11
+        default: 7
+        description: healpix zoom level of dataset
+        type: int

--- a/dkrz/disk/model-output/ifs-amip-tco3999/main.yaml
+++ b/dkrz/disk/model-output/ifs-amip-tco3999/main.yaml
@@ -1,0 +1,11 @@
+sources:
+  hist.v20250101.atmos.gr025:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20250101/atmos/gr025/main.yaml"
+    description: Output on 0.25 degree regular grid. This catalog contains the high-resolution (tco3999, ~2.8km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat
+  hist.v20250101.atmos.healpix:
+    args:
+      path: "{{CATALOG_DIR}}/hist/v20250101/atmos/healpix/main.yaml"
+    description: Output on HEALPix grid, on zoom levels 7 and 11, corresponding to grids H128 and H2048, with resolutions approximately 50.9 and 3.2 km. This catalog contains the high-resolution (tco3999, ~2.8km) EERIE IFS-AMIP historical production run, forced with ESA-CCI v3 SST & sea ice. v20250101 uses "reduced cloud-base mass flux".
+    driver: yaml_file_cat

--- a/dkrz/disk/model-output/main.yaml
+++ b/dkrz/disk/model-output/main.yaml
@@ -9,10 +9,15 @@ sources:
       path: "{{CATALOG_DIR}}/ifs-fesom2-sr/main.yaml"
     description: IFS-FESOM2 output available on DKRZ's Levante File System. This catalog contains datasets for all raw data in /work/bm1344 and accesses the data via kerchunks in /work/bm1344/DKRZ/kerchunks
     driver: yaml_file_cat
+  ifs-amip-tco3999:
+    args:
+      path: "{{CATALOG_DIR}}/ifs-amip-tco3999/main.yaml"
+    description: High-resolution (tco3999, ~ 2.8km) IFS-AMIP output available on DKRZ's Levante File System. With nextGEMS output and run with nextGEMS resources.
+    driver: yaml_file_cat
   ifs-amip-tco2559:
     args:
       path: "{{CATALOG_DIR}}/ifs-amip-tco2559/main.yaml"
-    description: High-resolution (tco2559, ~ 4.4km) IFS-AMIP output available on DKRZ's Levante File System. Currently only on scratch, not persistent
+    description: High-resolution (tco2559, ~ 4.4km) IFS-AMIP output available on DKRZ's Levante File System. 
     driver: yaml_file_cat
   ifs-amip-tco1279:
     args:


### PR DESCRIPTION
Adding tco3999 AMIP run
- following the cycle4 nextGEMS runs
- 14 months, 2020-01-01 - 2021-03-01
- currently only 2020 is available 